### PR TITLE
Try to prevent notifications immediately after alarm creation

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -47,7 +47,7 @@ def is_first_state_update(alarm_name):
 
     """
 
-    # Check the alarm history for state updates.
+    # Check the alarm history for 2 state updates.
     response = cloudwatch.describe_alarm_history(
         AlarmName=alarm_name,
         HistoryItemType='StateUpdate',
@@ -59,9 +59,9 @@ def is_first_state_update(alarm_name):
         logger.error('Could not check alarm history: %s', response)
         return False
     else:
-        # If only 1 state update was found, then this was the first one.
+        # If 2 state updates weren't returned, then this was the first one.
         state_update_count = len(response['AlarmHistoryItems'])
-        return state_update_count == 1
+        return state_update_count != 2
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
I have seen the occasional OK message being posted to Slack after an instance has launched. After checking the Lambda event and alarm history, it looks like it should have detected that it was the first state update and not posted to Slack. I suspect that it is a problem of eventual consistency and describe_alarm_history returned 0 state updates at the time, while this specifically checking for 1 state update. This changes it so that when there are 0 or 1 state updates, it is deemed as the first state update and it gets ignored.