### PR TITLE
Add option to append account details to message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ resource "aws_cloudwatch_metric_alarm" "other_alarm" {
 | slack\_url | The Slack webhook URL | string | n/a | yes |
 | sns\_topic\_arn | The SNS topic to subscribe to | string | n/a | yes |
 | tags |  | map | `<map>` | no |
+| account_append | Whether to append the account details to the message | bool | false | no
+| account_name | Optional display name for the account if appending | string | `""` | no

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,8 @@ module "lambda" {
       INSUFFICIENT_DATA_USER_NAME    = var.insufficient_data_user_name
       INSUFFICIENT_DATA_USER_EMOJI   = var.insufficient_data_user_emoji
       INSUFFICIENT_DATA_STATUS_EMOJI = var.insufficient_data_status_emoji
+      ACCOUNT_APPEND                 = var.account_append
+      ACCOUNT_NAME                   = var.account_name
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,8 +59,22 @@ variable "insufficient_data_status_emoji" {
   default = ":x:"
 }
 
+# Options for displaying account details:
+
+variable "account_append" {
+  description = "Whether to append the account details to the message."
+  type        = bool
+  default     = false
+}
+
+variable "account_name" {
+  description = "Optional display name for the account if appending."
+  type        = string
+  default     = ""
+}
+
 # Lambda layers, for testing the new Lambda execution environment:
-# https://aws.amazon.com/blogs/compute/upcoming-updates-to-the-aws-lambda-execution-environment/ 
+# https://aws.amazon.com/blogs/compute/upcoming-updates-to-the-aws-lambda-execution-environment/
 
 variable "lambda_layers" {
   default = []


### PR DESCRIPTION
Add the option of appending account details to help with messages from multiple accounts to the same hook.