### PR TITLE
msharpe/update_python3.6_python3.9_LambdaRunTime_claranet_slack_notif…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "lambda" {
   function_name = var.name
   description   = "Sends CloudWatch Alarm events to Slack"
   handler       = "lambda.lambda_handler"
-  runtime       = "python3.6"
+  runtime       = "python3.9"
   layers        = var.lambda_layers
   timeout       = 10
 


### PR DESCRIPTION
AWS is depricating python 3.6, so need to modify slack notification lambda function to use python 3.9.