### PR TITLE
Downgrading the python runtime from 3.9 to 3.8

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "lambda" {
   function_name = var.name
   description   = "Sends CloudWatch Alarm events to Slack"
   handler       = "lambda.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.8"
   layers        = var.lambda_layers
   timeout       = 10
 


### PR DESCRIPTION
Need to create a tag version with the runtime for Python being 3.8 